### PR TITLE
refactor: remove click package from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 grpcio>=1.39.0
 grpcio-reflection>=1.39.0
 google-api-core>=1.31.0
-click==7.1.2
 cryptography>=3.1.1


### PR DESCRIPTION
Hey @wesky93, 

I have run into some problems while using `grpc_requests`, as I had a dependency conflict between `click` and another package I'm using in my project because the version specified in requirements.txt is specific/strict. 
Moreover, I checked and didn't find you using click anywhere, so I suggest maybe removing it? or at least specifying ranges for package versions in order to offer developers more flexibility while resolving dependency conflicts.

Let me know your thoughts :)